### PR TITLE
games-emulation/citra: add missing dependency

### DIFF
--- a/games-emulation/citra/citra-9999.ebuild
+++ b/games-emulation/citra/citra-9999.ebuild
@@ -25,6 +25,7 @@ RDEPEND="virtual/opengl
 	qt5? (
 		dev-qt/qtcore:5
 		dev-qt/qtgui:5
+		dev-qt/qtmultimedia:5
 		dev-qt/qtopengl:5
 		dev-qt/qtwidgets:5
 		i18n? ( dev-qt/linguist-tools )


### PR DESCRIPTION
Citra would not compile due to missing qtmultimedia package